### PR TITLE
Provide the ability to include custom comments provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## HEAD
+
+- Add ability to provide a comments provider for pages and posts.
+
 ## 1.3.0 (2017-02-20)
 
 - Fix typos of the theme description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD
 
-- Add ability to provide a comments provider for pages and posts.
+- Add ability to provide a comments provider for pages and posts
 
 ## 1.3.0 (2017-02-20)
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ feed:
 
 Then create `<your-site>/atom.xml` with the same content of `feed.xml` above.
 
+### Comments
+whiteglass provides the ability to include your favourite commenting service, like [Disqus](https://disqus.com).
+
+To enable comments on pages and posts:
+1. Overwrite the `_includes/custom_comments_provider.html` with your custom provider of comments.
+2. Add `comments: on` to your `_config.yml`.
+
+To disable comments on certain posts or pages specify `comments: off` in the front matter of the page or post.
+
 ### Metadata for SEO
 
 #### Keywords

--- a/README.md
+++ b/README.md
@@ -218,13 +218,14 @@ feed:
 Then create `<your-site>/atom.xml` with the same content of `feed.xml` above.
 
 ### Comments
-whiteglass provides the ability to include your favourite commenting service, like [Disqus](https://disqus.com).
+
+whiteglass provides the ability to include your favourite commenting service, like [Disqus](https://disqus.com) or [Isso](https://posativ.org/isso).
 
 To enable comments on pages and posts:
 1. Overwrite the `_includes/custom_comments_provider.html` with your custom provider of comments.
-2. Add `comments: on` to your `_config.yml`.
+2. Add `comments: true` to your `_config.yml`.
 
-To disable comments on certain posts or pages specify `comments: off` in the front matter of the page or post.
+To disable comments on certain pages or posts specify `comments: false` in the front matter of the page or post.
 
 ### Metadata for SEO
 

--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ twitter_image:
 facebook_app_id:
 facebook_image:
 google_analytics:
-comments: off
+comments: false
 
 # Plugins
 gems:

--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,7 @@ twitter_image:
 facebook_app_id:
 facebook_image:
 google_analytics:
+comments: off
 
 # Plugins
 gems:

--- a/_includes/custom_comments_provider.html
+++ b/_includes/custom_comments_provider.html
@@ -1,0 +1,2 @@
+<h1>Comments</h1>
+<p>Insert your custom comment provider like <a href="https://disqus.com">Disqus</a> or <a href="https://posativ.org/isso">Isso</a> here.</p>

--- a/_includes/custom_comments_provider.html
+++ b/_includes/custom_comments_provider.html
@@ -1,2 +1,3 @@
+<hr />
 <h1>Comments</h1>
 <p>Insert your custom comment provider like <a href="https://disqus.com">Disqus</a> or <a href="https://posativ.org/isso">Isso</a> here.</p>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -12,3 +12,10 @@ layout: default
   </div>
 
 </article>
+
+{% if site.comments and page.comments != false %}
+  <div class"post-comments">
+  <hr />
+  {% include custom_comments_provider.html %}
+  </div>
+{% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -14,7 +14,7 @@ layout: default
 </article>
 
 {% if site.comments and page.comments != false %}
-  <div class"post-comments">
+  <div class="post-comments">
   <hr />
   {% include custom_comments_provider.html %}
   </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -15,7 +15,6 @@ layout: default
 
 {% if site.comments and page.comments != false %}
   <div class="post-comments">
-  <hr />
-  {% include custom_comments_provider.html %}
+    {% include custom_comments_provider.html %}
   </div>
 {% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -11,10 +11,10 @@ layout: default
     {{ content }}
   </div>
 
-</article>
+  {% if site.comments != false and page.comments != false %}
+    <div class="post-comments">
+      {% include custom_comments_provider.html %}
+    </div>
+  {% endif %}
 
-{% if site.comments and page.comments != false %}
-  <div class="post-comments">
-    {% include custom_comments_provider.html %}
-  </div>
-{% endif %}
+</article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,11 +16,10 @@ layout: default
     {{ content }}
   </div>
 
-</article>
+  {% if site.comments != false and page.comments != false %}
+    <div class="post-comments" itemprop="comment">
+      {% include custom_comments_provider.html %}
+    </div>
+  {% endif %}
 
-{% if site.comments and page.comments != false %}
-  <div class="post-comments">
-  <hr />
-  {% include custom_comments_provider.html %}
-  </div>
-{% endif %}
+</article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,7 +19,7 @@ layout: default
 </article>
 
 {% if site.comments and page.comments != false %}
-  <div class"post-comments">
+  <div class="post-comments">
   <hr />
   {% include custom_comments_provider.html %}
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -17,3 +17,10 @@ layout: default
   </div>
 
 </article>
+
+{% if site.comments and page.comments != false %}
+  <div class"post-comments">
+  <hr />
+  {% include custom_comments_provider.html %}
+  </div>
+{% endif %}

--- a/about.md
+++ b/about.md
@@ -173,7 +173,7 @@ whiteglass provides the ability to include your favourite commenting service, li
 
 To enable comments on pages and posts:
 1. Overwrite the `_includes/custom_comments_provider.html` with your custom provider of comments.
-2. Add `comments: false` to your `_config.yml`.
+2. Add `comments: true` to your `_config.yml`.
 
 To disable comments on certain pages or posts specify `comments: false` in the front matter of the page or post.
 

--- a/about.md
+++ b/about.md
@@ -169,7 +169,7 @@ categories:
 
 ### Comments
 
-whiteglass provides the ability to include your favourite commenting service, like [Disqus](https://disqus.com).
+whiteglass provides the ability to include your favourite commenting service, like [Disqus](https://disqus.com) or [Isso](https://posativ.org/isso).
 
 To enable comments on pages and posts:
 1. Overwrite the `_includes/custom_comments_provider.html` with your custom provider of comments.

--- a/about.md
+++ b/about.md
@@ -168,13 +168,14 @@ categories:
 ```
 
 ### Comments
+
 whiteglass provides the ability to include your favourite commenting service, like [Disqus](https://disqus.com).
 
 To enable comments on pages and posts:
 1. Overwrite the `_includes/custom_comments_provider.html` with your custom provider of comments.
-2. Add `comments: on` to your `_config.yml`.
+2. Add `comments: false` to your `_config.yml`.
 
-To disable comments on certain posts or pages specify `comments: off` in the front matter of the page or post.
+To disable comments on certain pages or posts specify `comments: false` in the front matter of the page or post.
 
 ### Metadata for SEO
 

--- a/about.md
+++ b/about.md
@@ -167,6 +167,15 @@ categories:
   - Idea
 ```
 
+### Comments
+whiteglass provides the ability to include your favourite commenting service, like [Disqus](https://disqus.com).
+
+To enable comments on pages and posts:
+1. Overwrite the `_includes/custom_comments_provider.html` with your custom provider of comments.
+2. Add `comments: on` to your `_config.yml`.
+
+To disable comments on certain posts or pages specify `comments: off` in the front matter of the page or post.
+
 ### Metadata for SEO
 
 #### Keywords


### PR DESCRIPTION
This commit provides the ability to include a custom comments provider.

As I'm not the expert in HTML, I'm happy to adjust the actual position of the include if the comments. I'd figured it would be best placed outside of the actual `<article>`-tag as it is not really a part of the article.