### PR TITLE
Appropriately size h1s in the post content

### DIFF
--- a/_sass/whiteglass/_layout.scss
+++ b/_sass/whiteglass/_layout.scss
@@ -160,6 +160,14 @@
 .post-content {
   margin-bottom: $spacing-unit;
 
+  h1 {
+    font-size: 38px;
+
+    @include media-query($on-laptop) {
+      font-size: 34px;
+    }
+  }
+
   h2 {
     font-size: 32px;
 


### PR DESCRIPTION
Perhaps bad practice, but I often use h1s in my article body as the top-level headers. At least, it should look reasonable if you do (currently the h1s are smaller than the h2s).

I've followed the scheme and made them 6px bigger than the h2s. However, this makes them quite close in size to the `.post-title` h1. It might be nice to scale all the `.post-content` headers by a couple of px.

