### PR TITLE
Don't ship _config.yml

### DIFF
--- a/jekyll-whiteglass.gemspec
+++ b/jekyll-whiteglass.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").select do |f|
-      f.match(%r{^(assets|_layouts|_includes|_sass|_data|_config\.yml|LICENSE|README|CHANGELOG)}i)
+      f.match(%r{^(assets|_layouts|_includes|_sass|_data|LICENSE|README|CHANGELOG)}i)
     end
   end
 


### PR DESCRIPTION
If the config file is included in the gem, then it will be applied to
users' site configurations alongside their own configuration.

This doesn't provide much benefit, since most of the configuration
options are either a) not applicable to users (e.g. the title setting),
or b) easily set by users to their own preferences (e.g. the markdown
settings).

Furthermore, some of the settings are actively harmful. In particular the `paginate`
options are from the old `jekyll-paginate`. In recent versions of
Jekyll, setting the old options causes build failures for users who are
using the newer `jekyll-paginate-v2`.

Overall, I think it's useful to have `_config.yml` in the repository as
an example, but I don't think we should ship it.