### PR TITLE
Fix SASS warnings

### DIFF
--- a/_sass/whiteglass/_base.scss
+++ b/_sass/whiteglass/_base.scss
@@ -39,7 +39,7 @@ h1, h2, h3, h4, h5, h6,
 p, blockquote, pre,
 ul, ol, dl, figure,
 %vertical-rhythm {
-  margin-bottom: $spacing-unit / 2;
+  margin-bottom: calc($spacing-unit / 2);
 }
 
 
@@ -127,7 +127,7 @@ a {
 blockquote {
   color: $grey-color;
   border-left: 4px solid $grey-color-light;
-  padding-left: $spacing-unit / 2;
+  padding-left: calc($spacing-unit / 2);
   font-size: 18px;
   letter-spacing: -1px;
   font-style: italic;
@@ -148,7 +148,7 @@ blockquote {
  */
 hr {
   height: 4px;
-  margin: $spacing-unit / 2 0;
+  margin: calc($spacing-unit / 2) 0;
   border: 0;
   background-color: $grey-color-light;
 }
@@ -200,8 +200,8 @@ pre {
   @include media-query($on-laptop) {
     max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit}));
     max-width:         calc(#{$content-width} - (#{$spacing-unit}));
-    padding-right: $spacing-unit / 2;
-    padding-left: $spacing-unit / 2;
+    padding-right: calc($spacing-unit / 2);
+    padding-left: calc($spacing-unit / 2);
   }
 }
 

--- a/_sass/whiteglass/_layout.scss
+++ b/_sass/whiteglass/_layout.scss
@@ -199,7 +199,7 @@
  * Pagination
  */
 .pagination {
-  padding: $spacing-unit / 2 0;
+  padding: calc($spacing-unit / 2) 0;
   border-top: 1px solid $grey-color-light;
   border-bottom: 1px solid $grey-color-light;
   text-align: center;


### PR DESCRIPTION
Thank you for making the theme available. I've been [using it](https://ylan.segal-family.com/) happily for a few years now!

I upgraded recently to the latest jekyll (4.3.1), and found some SASS warnings like this one:

```
      Regenerating: 1 file(s) changed at 2022-12-27 02:40:10
                    _sass/whiteglass/_base.scss
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($spacing-unit, 2) or calc($spacing-unit / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
42 │   margin-bottom: $spacing-unit / 2;
   │                  ^^^^^^^^^^^^^^^^^
   ╵
    /Users/ylansegal/Personal/whiteglass/_sass/whiteglass/_base.scss 42:18  @import
    whiteglass.scss 44:3                                                    @import
    /Users/ylansegal/Personal/whiteglass/assets/main.scss 46:9              root stylesheet
```
As [recommended](https://sass-lang.com/documentation/breaking-changes/slash-div), I fixed with `calc`, since that didn't require any new imports. 

As far as I can tell, the generated `main.css` is identical:

```
$ curl http://127.0.0.1:4000/whiteglass/assets/main.css > before.main.css

$ git switch fix_sass_warnings
# bundle exec jekyll serve regenerates in a separate window

$ curl http://127.0.0.1:4000/whiteglass/assets/main.css > after.main.css

$ diff before.main.css after.main.css
# no output, no diff!
```