### PR TITLE
Update outdated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Then create `<your-site>/atom.xml` with the same content of `feed.xml` above.
 
 ### Comments
 
-whiteglass provides the ability to include your favourite commenting service, like [Disqus](https://disqus.com) or [Isso](https://posativ.org/isso).
+whiteglass provides the ability to include your favourite commenting service, like [Disqus](https://disqus.com) or [Isso](https://isso-comments.de/).
 
 To enable comments on pages and posts:
 1. Overwrite the `_includes/custom_comments_provider.html` with your custom provider of comments.

--- a/about.md
+++ b/about.md
@@ -277,7 +277,7 @@ Then create `<your-site>/atom.xml` with the same content of `feed.xml` above.
 
 ### Comments
 
-whiteglass provides the ability to include your favourite commenting service, like [Disqus](https://disqus.com) or [Isso](https://posativ.org/isso).
+whiteglass provides the ability to include your favourite commenting service, like [Disqus](https://disqus.com) or [Isso](https://isso-comments.de/).
 
 To enable comments on pages and posts:
 1. Overwrite the `_includes/custom_comments_provider.html` with your custom provider of comments.


### PR DESCRIPTION
Previous link had expired SSL certificate and generated a warning on Chrome and failed HTML Proofer test.