### PR TITLE
Add MathJax block and inline equation

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -66,4 +66,18 @@
 
   {% include fonts.html %}
   {% include google_analytics.html %}
+
+  <!-- mathjax -->
+  <!-- https://docs.mathjax.org/en/v3.0-latest/web/start.html#using-mathjax-from-a-content-delivery-network-cdn -->
+  <!-- https://docs.mathjax.org/en/v3.0-latest/web/start.html#configuring-mathjax -->
+  <script>
+      MathJax = {
+          tex: {
+              inlineMath: [['$', '$'], ['\\(', '\\)']]
+          }
+      };
+  </script>
+  <script id="MathJax-script" async
+          src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+  </script>  
 </head>

--- a/_posts/2017-01-05-welcome-to-jekyll.md
+++ b/_posts/2017-01-05-welcome-to-jekyll.md
@@ -15,6 +15,14 @@ print_hi('Tom')
 #=> prints 'Hi, Tom' to STDOUT.
 {% endhighlight %}
 
+And whiteglass also support MathJax:
+
+$$
+\sum_{i=1}^n a_i=1004
+$$
+
+of course, you can use inline equation $$ax^2 + bx + c = 0$$ too.
+
 Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most out of Jekyll. File all bugs/feature requests at [Jekyll’s GitHub repo][jekyll-gh]. If you have questions, you can ask them on [Jekyll Talk][jekyll-talk].
 
 [jekyll-docs]: http://jekyllrb.com/docs/home


### PR DESCRIPTION
## Why MathJax?

[GitHub supports MathJax in Markdown](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions#about-writing-mathematical-expressions), ensuring compatibility with Jekyll as well.

## Changes

- Added MathJax component
- Support for block equations with `$$`
- Support for inline equations with `$` or `\\(` `\\)`

### Testing

Successfully tested in the local environment. Refer to the screenshot below:

![Snipaste_2023-12-23_20-29-51](https://github.com/yous/whiteglass/assets/97666463/3f091e42-1c40-4fd1-a1a6-fdf8d201ae7f)

Thank you for your theme!
